### PR TITLE
ci: align main branch workflows to ARC scale set (hetzner-thxnet)

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   image:
     name: Build and publish images
-    runs-on: [hetzner]
+    runs-on: hetzner-thxnet
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -19,7 +19,7 @@ env:
 jobs:
   format:
     name: Lint format
-    runs-on: [hetzner]
+    runs-on: hetzner-thxnet
     steps:
       - uses: actions/checkout@v3
 
@@ -60,7 +60,7 @@ jobs:
 
   commit:
     name: Lint commit
-    runs-on: [hetzner]
+    runs-on: hetzner-thxnet
     steps:
       - uses: actions/checkout@v3
         with:
@@ -73,7 +73,7 @@ jobs:
 
   codespell:
     name: Codespell
-    runs-on: [hetzner]
+    runs-on: hetzner-thxnet
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -19,7 +19,7 @@ env:
 jobs:
   build-nix-flake:
     name: Build Nix Flake
-    runs-on: [hetzner]
+    runs-on: hetzner-thxnet
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ env:
 jobs:
   all:
     name: Release
-    runs-on: [hetzner]
+    runs-on: hetzner-thxnet
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   rustfmt:
     name: Check Rust format
-    runs-on: [hetzner]
+    runs-on: hetzner-thxnet
     steps:
       - uses: actions/checkout@v3
 
@@ -87,7 +87,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: [hetzner]
+    runs-on: hetzner-thxnet
     needs:
       - rustfmt
     steps:
@@ -131,7 +131,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: [hetzner]
+    runs-on: hetzner-thxnet
     needs:
       - clippy
       # - udeps


### PR DESCRIPTION
## Summary

`main` is not the default branch (default is `develop`, which is already fully compliant) but it still carries `runs-on: [hetzner]` — a ghost label that queues CI runs forever because no ARC scale set with that name exists.

Normalising to scalar `hetzner-thxnet`, matching the scale-set name the `gha-runner-scale-set` broker routes on. This is identical to the policy already enforced on `develop` and in the upcoming `feat/leafchains-ci-runner-selector` policy guard.

## Change table

| file:line | old | new |
|---|---|---|
| .github/workflows/integration.yaml:32 | `[hetzner]` | `hetzner-thxnet` |
| .github/workflows/lints.yaml:22 | `[hetzner]` | `hetzner-thxnet` |
| .github/workflows/lints.yaml:63 | `[hetzner]` | `hetzner-thxnet` |
| .github/workflows/lints.yaml:76 | `[hetzner]` | `hetzner-thxnet` |
| .github/workflows/nix.yaml:22 | `[hetzner]` | `hetzner-thxnet` |
| .github/workflows/release.yaml:26 | `[hetzner]` | `hetzner-thxnet` |
| .github/workflows/rust.yaml:34 | `[hetzner]` | `hetzner-thxnet` |
| .github/workflows/rust.yaml:90 | `[hetzner]` | `hetzner-thxnet` |
| .github/workflows/rust.yaml:134 | `[hetzner]` | `hetzner-thxnet` |

9 `runs-on:` lines across 5 files. Nothing else touched.

THXLAB AI Team